### PR TITLE
Use Precise instead of Trusty for PHP 5.3 builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: php
 
+sudo: false
+dist: precise
+
 php:
-  - "5.6"
-  - "5.5"
-  - "5.4"
-  - "5.3"
-  - "7.0"
+  - 5.6
+  - 5.5
+  - 5.4
+  - 5.3
+  - 7.0
   - hhvm
 
 before_script:


### PR DESCRIPTION
Travis CI does not support PHP 5.3(.x) versions on Trusty. In order to prevent build failure, Precise must be used instead.

https://docs.travis-ci.com/user/languages/php#PHP-5.2(.x)-and-5.3(.x)-support-is-available-on-Precise-only
https://docs.travis-ci.com/user/reference/trusty#PHP-images

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming