### PR TITLE
Replaced Dependency on Zend\Config with usage of ArrayAccess Interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-config": "~2.2",
         "zendframework/zend-di": "~2.2"
     },
     "require-dev": {

--- a/library/Odesk/Phystrix/AbstractCommand.php
+++ b/library/Odesk/Phystrix/AbstractCommand.php
@@ -19,6 +19,7 @@
 namespace Odesk\Phystrix;
 
 use ArrayAccess;
+use ArrayObject;
 use Odesk\Phystrix\Configuration\PhystrixCommandConfiguration;
 use Odesk\Phystrix\Exception\BadRequestException;
 use Odesk\Phystrix\Exception\FallbackNotAvailableException;
@@ -48,7 +49,7 @@ abstract class AbstractCommand
     protected $commandKey;
 
     /**
-     * @var ArrayAccess
+     * @var array
      */
     protected $config;
 
@@ -176,9 +177,11 @@ abstract class AbstractCommand
     {
         $commandKey = $this->getCommandKey();
         $this->config = $phystrixConfig->offsetGet('default');
-        $this->config->merge($phystrixConfig->offsetGet($commandKey));
+        if ($phystrixConfig->offsetExists($commandKey)){
+            $this->config = array_merge($this->config, $phystrixConfig->offsetGet($commandKey));
+        }
 
-        $this->config = new PhystrixCommandConfiguration($this->config);
+        $this->commandConfig = new PhystrixCommandConfiguration(new ArrayObject($this->config));
     }
 
     /**

--- a/library/Odesk/Phystrix/AbstractCommand.php
+++ b/library/Odesk/Phystrix/AbstractCommand.php
@@ -18,6 +18,8 @@
  */
 namespace Odesk\Phystrix;
 
+use ArrayAccess;
+use Odesk\Phystrix\Configuration\PhystrixCommandConfiguration;
 use Odesk\Phystrix\Exception\BadRequestException;
 use Odesk\Phystrix\Exception\FallbackNotAvailableException;
 use Odesk\Phystrix\Exception\RuntimeException;
@@ -49,7 +51,7 @@ abstract class AbstractCommand
     /**
      * Command configuration
      *
-     * @var Config
+     * @var PhystrixCommandConfiguration
      */
     protected $config;
 
@@ -164,17 +166,15 @@ abstract class AbstractCommand
     /**
      * Sets base command configuration from the global phystrix configuration
      *
-     * @param Config $phystrixConfig
+     * @param ArrayAccess $phystrixConfig
      */
-    public function initializeConfig(Config $phystrixConfig)
+    public function initializeConfig(ArrayAccess $phystrixConfig)
     {
         $commandKey = $this->getCommandKey();
-        $config = new Config($phystrixConfig->get('default')->toArray(), true);
-        if ($phystrixConfig->__isset($commandKey)) {
-            $commandConfig = $phystrixConfig->get($commandKey);
-            $config->merge($commandConfig);
-        }
-        $this->config = $config;
+        $config = $phystrixConfig->offsetGet('default');
+        $config->merge($phystrixConfig->offsetGet($commandKey));
+
+        $this->config = new PhystrixCommandConfiguration($config);
     }
 
     /**

--- a/library/Odesk/Phystrix/AbstractCommand.php
+++ b/library/Odesk/Phystrix/AbstractCommand.php
@@ -187,18 +187,22 @@ abstract class AbstractCommand
     /**
      * Sets configuration for the command, allows to override config in runtime
      *
-     * @param Config $config
+     * @param array $phystrixConfig
      * @param bool $merge
      */
-    public function setConfig(Config $config, $merge = true)
+    public function setConfig(array $phystrixConfig, $merge = true)
     {
         if ($this->config && $merge) {
-            $this->config->merge($config);
+            $this->config = array_merge($this->config, $phystrixConfig);
         } else {
-            $this->config = $config;
+            $this->config = $phystrixConfig;
         }
 
-        $this->commandConfig->updateConfiguration($this->config);
+        if (null === $this->commandConfig) {
+            $this->commandConfig = new PhystrixCommandConfiguration(new ArrayObject($this->config));
+        } else {
+            $this->commandConfig->updateConfiguration(new ArrayObject($this->config));
+        }
     }
 
     /**

--- a/library/Odesk/Phystrix/AbstractCommand.php
+++ b/library/Odesk/Phystrix/AbstractCommand.php
@@ -176,7 +176,12 @@ abstract class AbstractCommand
     public function initializeConfig(ArrayAccess $phystrixConfig)
     {
         $commandKey = $this->getCommandKey();
-        $this->config = $phystrixConfig->offsetGet('default');
+
+        $this->config =
+            $phystrixConfig->offsetExists('default')
+                ? $phystrixConfig->offsetGet('default')
+                : array();
+
         if ($phystrixConfig->offsetExists($commandKey)){
             $this->config = array_merge($this->config, $phystrixConfig->offsetGet($commandKey));
         }

--- a/library/Odesk/Phystrix/CircuitBreaker.php
+++ b/library/Odesk/Phystrix/CircuitBreaker.php
@@ -87,19 +87,19 @@ class CircuitBreaker implements CircuitBreakerInterface
         }
 
         $healthCounts = $this->metrics->getHealthCounts();
-        if ($healthCounts->getTotal() < $this->circuitBreakerConfig->getRequestVolumeThreshold()) {
+        if ($healthCounts->getTotal() < $this->circuitBreakerConfig->getCircuitBreakerRequestVolumeThreshold()) {
             // we are not past the minimum volume threshold for the statistical window
             // so we'll return false immediately and not calculate anything
             return false;
         }
 
-        $allowedErrorPercentage = $this->circuitBreakerConfig->getErrorThresholdPercentage();
+        $allowedErrorPercentage = $this->circuitBreakerConfig->getCircuitBreakerErrorThresholdPercentage();
         if ($healthCounts->getErrorPercentage() < $allowedErrorPercentage) {
             return false;
         } else {
             $this->stateStorage->openCircuit(
                 $this->commandKey,
-                $this->circuitBreakerConfig->getSleepWindowInMilliseconds()
+                $this->circuitBreakerConfig->getCircuitBreakerSleepWindowInMilliseconds()
             );
             return true;
         }
@@ -114,7 +114,7 @@ class CircuitBreaker implements CircuitBreakerInterface
     {
         return $this->stateStorage->allowSingleTest(
             $this->commandKey,
-            $this->circuitBreakerConfig->getSleepWindowInMilliseconds()
+            $this->circuitBreakerConfig->getCircuitBreakerSleepWindowInMilliseconds()
         );
     }
 
@@ -125,10 +125,10 @@ class CircuitBreaker implements CircuitBreakerInterface
      */
     public function allowRequest()
     {
-        if ($this->circuitBreakerConfig->isForceOpened()) {
+        if ($this->circuitBreakerConfig->isCircuitBreakerForceOpened()) {
             return false;
         }
-        if ($this->circuitBreakerConfig->isForceClosed()) {
+        if ($this->circuitBreakerConfig->isCircuitBreakerForceClosed()) {
             return true;
         }
 

--- a/library/Odesk/Phystrix/CircuitBreakerFactory.php
+++ b/library/Odesk/Phystrix/CircuitBreakerFactory.php
@@ -18,7 +18,7 @@
  */
 namespace Odesk\Phystrix;
 
-use Zend\Config\Config;
+use Odesk\Phystrix\Configuration\PhystrixCommandConfiguration;
 
 /**
  * Factory to keep track of and instantiate new circuit breakers when needed
@@ -49,15 +49,14 @@ class CircuitBreakerFactory
      * Get circuit breaker instance by command key for given command config
      *
      * @param string $commandKey
-     * @param Config $commandConfig
+     * @param PhystrixCommandConfiguration $commandConfig
      * @param CommandMetrics $metrics
      * @return CircuitBreakerInterface
      */
-    public function get($commandKey, Config $commandConfig, CommandMetrics $metrics)
+    public function get($commandKey, PhystrixCommandConfiguration $commandConfig, CommandMetrics $metrics)
     {
         if (!isset($this->circuitBreakersByCommand[$commandKey])) {
-            $circuitBreakerConfig = $commandConfig->get('circuitBreaker');
-            if ($circuitBreakerConfig->get('enabled')) {
+            if ($commandConfig->isEnabled()) {
                 $this->circuitBreakersByCommand[$commandKey] =
                     new CircuitBreaker($commandKey, $metrics, $commandConfig, $this->stateStorage);
             } else {

--- a/library/Odesk/Phystrix/CircuitBreakerFactory.php
+++ b/library/Odesk/Phystrix/CircuitBreakerFactory.php
@@ -56,7 +56,7 @@ class CircuitBreakerFactory
     public function get($commandKey, PhystrixCommandConfiguration $commandConfig, CommandMetrics $metrics)
     {
         if (!isset($this->circuitBreakersByCommand[$commandKey])) {
-            if ($commandConfig->isEnabled()) {
+            if ($commandConfig->isCircuitBreakerEnabled()) {
                 $this->circuitBreakersByCommand[$commandKey] =
                     new CircuitBreaker($commandKey, $metrics, $commandConfig, $this->stateStorage);
             } else {

--- a/library/Odesk/Phystrix/CommandFactory.php
+++ b/library/Odesk/Phystrix/CommandFactory.php
@@ -19,9 +19,7 @@
 namespace Odesk\Phystrix;
 
 use ArrayAccess;
-use ArrayObject;
 use ReflectionClass;
-use Zend\Config\Config;
 use Zend\Di\LocatorInterface;
 
 /**
@@ -31,7 +29,7 @@ use Zend\Di\LocatorInterface;
 class CommandFactory
 {
     /**
-     * @var Config
+     * @var ArrayAccess
      */
     protected $config;
 

--- a/library/Odesk/Phystrix/CommandFactory.php
+++ b/library/Odesk/Phystrix/CommandFactory.php
@@ -18,6 +18,8 @@
  */
 namespace Odesk\Phystrix;
 
+use ArrayAccess;
+use ArrayObject;
 use ReflectionClass;
 use Zend\Config\Config;
 use Zend\Di\LocatorInterface;
@@ -61,7 +63,7 @@ class CommandFactory
     /**
      * Constructor
      *
-     * @param Config $config
+     * @param ArrayAccess $config
      * @param LocatorInterface $serviceLocator
      * @param CircuitBreakerFactory $circuitBreakerFactory
      * @param CommandMetricsFactory $commandMetricsFactory
@@ -69,7 +71,7 @@ class CommandFactory
      * @param RequestLog $requestLog
      */
     public function __construct(
-        Config $config,
+        ArrayAccess $config,
         LocatorInterface $serviceLocator,
         CircuitBreakerFactory $circuitBreakerFactory,
         CommandMetricsFactory $commandMetricsFactory,
@@ -89,6 +91,7 @@ class CommandFactory
      *
      * @param string $class
      * @return AbstractCommand
+     * @throws \ReflectionException
      */
     public function getCommand($class)
     {

--- a/library/Odesk/Phystrix/CommandMetricsFactory.php
+++ b/library/Odesk/Phystrix/CommandMetricsFactory.php
@@ -19,7 +19,7 @@
 
 namespace Odesk\Phystrix;
 
-use Iterator;
+use Odesk\Phystrix\Configuration\MetricsConfigurationInterface;
 
 /**
  * Factory to keep track of and instantiate new command metrics objects when needed
@@ -57,25 +57,15 @@ class CommandMetricsFactory
      * Get command metrics instance by command key for given command config
      *
      * @param string $commandKey
-     * @param Iterator $iterableConfiguration
+     * @param MetricsConfigurationInterface $metricsConfiguration
      * @return CommandMetrics
      */
-    public function get($commandKey, Iterator $iterableConfiguration)
+    public function get($commandKey, MetricsConfigurationInterface $metricsConfiguration)
     {
         if (!isset($this->commandMetricsByCommand[$commandKey])) {
-            $configuration = iterator_to_array($iterableConfiguration);
-            $statisticalWindow = $this->getConfigurationValue(
-                $configuration,
-                'metrics.rollingStatisticalWindowInMilliseconds'
-            );
-            $windowBuckets = $this->getConfigurationValue(
-                $configuration,
-                'metrics.rollingStatisticalWindowBuckets'
-            );
-            $snapshotInterval = $this->getConfigurationValue(
-                $configuration,
-                'metrics.healthSnapshotIntervalInMilliseconds'
-            );
+            $statisticalWindow = $metricsConfiguration->getRollingStatisticalWindowInMilliseconds();
+            $windowBuckets = $metricsConfiguration->getRollingStatisticalWindowBuckets();
+            $snapshotInterval = $metricsConfiguration->getHealthSnapshotIntervalInMilliseconds();
 
             $counter = new MetricsCounter($commandKey, $this->stateStorage, $statisticalWindow, $windowBuckets);
             $this->commandMetricsByCommand[$commandKey] = new CommandMetrics($counter, $snapshotInterval);

--- a/library/Odesk/Phystrix/CommandMetricsFactory.php
+++ b/library/Odesk/Phystrix/CommandMetricsFactory.php
@@ -63,9 +63,9 @@ class CommandMetricsFactory
     public function get($commandKey, MetricsConfigurationInterface $metricsConfiguration)
     {
         if (!isset($this->commandMetricsByCommand[$commandKey])) {
-            $statisticalWindow = $metricsConfiguration->getRollingStatisticalWindowInMilliseconds();
-            $windowBuckets = $metricsConfiguration->getRollingStatisticalWindowBuckets();
-            $snapshotInterval = $metricsConfiguration->getHealthSnapshotIntervalInMilliseconds();
+            $statisticalWindow = $metricsConfiguration->getMetricsRollingStatisticalWindowInMilliseconds();
+            $windowBuckets = $metricsConfiguration->getMetricsRollingStatisticalWindowBuckets();
+            $snapshotInterval = $metricsConfiguration->getMetricsHealthSnapshotIntervalInMilliseconds();
 
             $counter = new MetricsCounter($commandKey, $this->stateStorage, $statisticalWindow, $windowBuckets);
             $this->commandMetricsByCommand[$commandKey] = new CommandMetrics($counter, $snapshotInterval);

--- a/library/Odesk/Phystrix/Configuration/CircuitBreakerConfigurationInterface.php
+++ b/library/Odesk/Phystrix/Configuration/CircuitBreakerConfigurationInterface.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is a part of the Phystrix library
+ *
+ * Copyright 2013-2014 oDesk Corporation. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Odesk\Phystrix\Configuration;
+
+/**
+ * Circuit-Breaker configuration interface
+ */
+interface CircuitBreakerConfigurationInterface
+{
+    const CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE = 'errorThresholdPercentage';
+    const CONFIG_KEY_FORCE_CLOSED = 'forceClosed';
+    const CONFIG_KEY_FORCE_OPENED = 'forceOpen';
+    const CONFIG_KEY_REQUEST_VOLUME_THRESHOLD = 'requestVolumeThreshold';
+    const CONFIG_KEY_SLEEP_WINDOW_IN_MILLISECONDS = 'sleepWindowInMilliseconds';
+
+    /**
+     * @return integer
+     */
+    public function getErrorThresholdPercentage();
+
+    /**
+     * @return integer
+     */
+    public function getRequestVolumeThreshold();
+
+    /**
+     * @return integer
+     */
+    public function getSleepWindowInMilliseconds();
+
+    /**
+     * @return boolean
+     */
+    public function isForceClosed();
+
+    /**
+     * @return boolean
+     */
+    public function isForceOpened();
+}

--- a/library/Odesk/Phystrix/Configuration/CircuitBreakerConfigurationInterface.php
+++ b/library/Odesk/Phystrix/Configuration/CircuitBreakerConfigurationInterface.php
@@ -23,40 +23,40 @@ namespace Odesk\Phystrix\Configuration;
  */
 interface CircuitBreakerConfigurationInterface
 {
-    const CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE = 'errorThresholdPercentage';
-    const CONFIG_KEY_ENABLED = 'enabled';
-    const CONFIG_KEY_FORCE_CLOSED = 'forceClosed';
-    const CONFIG_KEY_FORCE_OPENED = 'forceOpen';
-    const CONFIG_KEY_REQUEST_VOLUME_THRESHOLD = 'requestVolumeThreshold';
-    const CONFIG_KEY_SLEEP_WINDOW_IN_MILLISECONDS = 'sleepWindowInMilliseconds';
+    const CB_CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE = 'errorThresholdPercentage';
+    const CB_CONFIG_KEY_ENABLED = 'enabled';
+    const CB_CONFIG_KEY_FORCE_CLOSED = 'forceClosed';
+    const CB_CONFIG_KEY_FORCE_OPENED = 'forceOpen';
+    const CB_CONFIG_KEY_REQUEST_VOLUME_THRESHOLD = 'requestVolumeThreshold';
+    const CB_CONFIG_KEY_SLEEP_WINDOW_IN_MILLISECONDS = 'sleepWindowInMilliseconds';
 
     /**
      * @return integer
      */
-    public function getErrorThresholdPercentage();
+    public function getCircuitBreakerErrorThresholdPercentage();
 
     /**
      * @return integer
      */
-    public function getRequestVolumeThreshold();
+    public function getCircuitBreakerRequestVolumeThreshold();
 
     /**
      * @return integer
      */
-    public function getSleepWindowInMilliseconds();
+    public function getCircuitBreakerSleepWindowInMilliseconds();
 
     /**
      * @return boolean
      */
-    public function isEnabled();
+    public function isCircuitBreakerEnabled();
 
     /**
      * @return boolean
      */
-    public function isForceClosed();
+    public function isCircuitBreakerForceClosed();
 
     /**
      * @return boolean
      */
-    public function isForceOpened();
+    public function isCircuitBreakerForceOpened();
 }

--- a/library/Odesk/Phystrix/Configuration/CircuitBreakerConfigurationInterface.php
+++ b/library/Odesk/Phystrix/Configuration/CircuitBreakerConfigurationInterface.php
@@ -24,6 +24,7 @@ namespace Odesk\Phystrix\Configuration;
 interface CircuitBreakerConfigurationInterface
 {
     const CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE = 'errorThresholdPercentage';
+    const CONFIG_KEY_ENABLED = 'enabled';
     const CONFIG_KEY_FORCE_CLOSED = 'forceClosed';
     const CONFIG_KEY_FORCE_OPENED = 'forceOpen';
     const CONFIG_KEY_REQUEST_VOLUME_THRESHOLD = 'requestVolumeThreshold';
@@ -43,6 +44,11 @@ interface CircuitBreakerConfigurationInterface
      * @return integer
      */
     public function getSleepWindowInMilliseconds();
+
+    /**
+     * @return boolean
+     */
+    public function isEnabled();
 
     /**
      * @return boolean

--- a/library/Odesk/Phystrix/Configuration/FallbackConfigurationInterface.php
+++ b/library/Odesk/Phystrix/Configuration/FallbackConfigurationInterface.php
@@ -19,28 +19,14 @@
 namespace Odesk\Phystrix\Configuration;
 
 /**
- * Metrics configuration interface
+ * Fallback configuration interface
  */
-interface MetricsConfigurationInterface
+interface FallbackConfigurationInterface
 {
-    const MT_CONFIG_KEY_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS = 'healthSnapshotIntervalInMilliseconds';
-    const MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_BUCKETS = 'rollingStatisticalWindowBuckets';
-    const MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_IN_MILLISECONDS = 'rollingStatisticalWindowInMilliseconds';
-
-
+    const FB_CONFIG_KEY_ENABLED = 'enabled';
 
     /**
-     * @return integer
+     * @return boolean
      */
-    public function getMetricsHealthSnapshotIntervalInMilliseconds();
-
-    /**
-     * @return integer
-     */
-    public function getMetricsRollingStatisticalWindowBuckets();
-
-    /**
-     * @return integer
-     */
-    public function getMetricsRollingStatisticalWindowInMilliseconds();
+    public function isFallbackEnabled();
 }

--- a/library/Odesk/Phystrix/Configuration/MetricsConfigurationInterface.php
+++ b/library/Odesk/Phystrix/Configuration/MetricsConfigurationInterface.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is a part of the Phystrix library
+ *
+ * Copyright 2013-2014 oDesk Corporation. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Odesk\Phystrix\Configuration;
+
+/**
+ * Metrics configuration interface
+ */
+interface MetricsConfigurationInterface
+{
+    const CONFIG_KEY_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS = 'healthSnapshotIntervalInMilliseconds';
+    const CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_BUCKETS = 'rollingStatisticalWindowBuckets';
+    const CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_IN_MILLISECONDS = 'rollingStatisticalWindowInMilliseconds';
+
+
+
+    /**
+     * @return integer
+     */
+    public function getHealthSnapshotIntervalInMilliseconds();
+
+    /**
+     * @return integer
+     */
+    public function getRollingStatisticalWindowBuckets();
+
+    /**
+     * @return integer
+     */
+    public function getRollingStatisticalWindowInMilliseconds();
+}

--- a/library/Odesk/Phystrix/Configuration/PhystrixCommandConfiguration.php
+++ b/library/Odesk/Phystrix/Configuration/PhystrixCommandConfiguration.php
@@ -58,6 +58,13 @@ class PhystrixCommandConfiguration implements
 
     public function __construct(ArrayAccess $configuration)
     {
+        $this->updateConfiguration($configuration);
+    }
+
+    /**
+     * @param ArrayAccess $configuration
+     */
+    public function updateConfiguration(ArrayAccess $configuration){
         $this->circuitBreakerConfiguration =
             $configuration->offsetExists('circuitBreaker')
                 ? $configuration->offsetGet('circuitBreaker')

--- a/library/Odesk/Phystrix/Configuration/PhystrixCommandConfiguration.php
+++ b/library/Odesk/Phystrix/Configuration/PhystrixCommandConfiguration.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * This file is a part of the Phystrix library
+ *
+ * Copyright 2013-2014 oDesk Corporation. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Odesk\Phystrix\Configuration;
+
+use Iterator;
+
+/**
+ * Phystrix command configuration class
+ */
+class PhystrixCommandConfiguration implements MetricsConfigurationInterface, CircuitBreakerConfigurationInterface
+{
+    /**
+     * @var array
+     */
+    private $configuration;
+
+    /**
+     * @var array
+     */
+    private $circuitBreakerConfiguration = array();
+
+    /**
+     * @var array
+     */
+    private $metricsConfiguration = array();
+
+    public function __construct(Iterator $configurationIterator)
+    {
+        $this->configuration = iterator_to_array($configurationIterator);
+        if (array_key_exists('circuitBreaker', $this->configuration)) {
+            $this->circuitBreakerConfiguration = $this->configuration['circuitBreaker'];
+        }
+        if (array_key_exists('metrics', $this->configuration)) {
+            $this->metricsConfiguration = $this->configuration['metrics'];
+        }
+    }
+
+    /**
+     * @return integer
+     */
+    public function getHealthSnapshotIntervalInMilliseconds()
+    {
+        return $this->getConfigurationValue(
+            $this->metricsConfiguration,
+            MetricsConfigurationInterface::CONFIG_KEY_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS,
+            0
+        );
+    }
+
+    /**
+     * @return integer
+     */
+    public function getRollingStatisticalWindowBuckets()
+    {
+        return $this->getConfigurationValue(
+            $this->metricsConfiguration,
+            MetricsConfigurationInterface::CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_BUCKETS,
+            0
+        );
+    }
+
+    /**
+     * @return integer
+     */
+    public function getRollingStatisticalWindowInMilliseconds()
+    {
+        return $this->getConfigurationValue(
+            $this->metricsConfiguration,
+            MetricsConfigurationInterface::CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_IN_MILLISECONDS,
+            0
+        );
+    }
+
+    /**
+     * @return integer
+     */
+    public function getErrorThresholdPercentage()
+    {
+        return $this->getConfigurationValue(
+            $this->circuitBreakerConfiguration,
+            CircuitBreakerConfigurationInterface::CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE,
+            0
+        );
+    }
+
+    /**
+     * @return integer
+     */
+    public function getRequestVolumeThreshold()
+    {
+        return $this->getConfigurationValue(
+            $this->circuitBreakerConfiguration,
+            CircuitBreakerConfigurationInterface::CONFIG_KEY_REQUEST_VOLUME_THRESHOLD,
+            0
+        );
+    }
+
+    /**
+     * @return integer
+     */
+    public function getSleepWindowInMilliseconds()
+    {
+        return $this->getConfigurationValue(
+            $this->circuitBreakerConfiguration,
+            CircuitBreakerConfigurationInterface::CONFIG_KEY_SLEEP_WINDOW_IN_MILLISECONDS,
+            0
+        );
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isForceClosed()
+    {
+        return $this->getConfigurationValue(
+            $this->circuitBreakerConfiguration,
+            CircuitBreakerConfigurationInterface::CONFIG_KEY_FORCE_CLOSED,
+            false
+        );
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isForceOpened()
+    {
+        return $this->getConfigurationValue(
+            $this->circuitBreakerConfiguration,
+            CircuitBreakerConfigurationInterface::CONFIG_KEY_FORCE_OPENED,
+            false
+        );
+    }
+    /**
+     * @param array $configuration
+     * @param string $key
+     * @param mixed|null $default
+     * @return mixed|null
+     */
+    private function getConfigurationValue(array $configuration, $key, $default = null)
+    {
+        if (!array_key_exists($key, $configuration))
+        {
+            return $default;
+        }
+
+        return $configuration[$key];
+    }
+}

--- a/library/Odesk/Phystrix/Configuration/PhystrixCommandConfiguration.php
+++ b/library/Odesk/Phystrix/Configuration/PhystrixCommandConfiguration.php
@@ -19,18 +19,13 @@
 
 namespace Odesk\Phystrix\Configuration;
 
-use Iterator;
+use ArrayAccess;
 
 /**
  * Phystrix command configuration class
  */
 class PhystrixCommandConfiguration implements MetricsConfigurationInterface, CircuitBreakerConfigurationInterface
 {
-    /**
-     * @var array
-     */
-    private $configuration;
-
     /**
      * @var array
      */
@@ -41,15 +36,10 @@ class PhystrixCommandConfiguration implements MetricsConfigurationInterface, Cir
      */
     private $metricsConfiguration = array();
 
-    public function __construct(Iterator $configurationIterator)
+    public function __construct(ArrayAccess $configurationIterator)
     {
-        $this->configuration = iterator_to_array($configurationIterator);
-        if (array_key_exists('circuitBreaker', $this->configuration)) {
-            $this->circuitBreakerConfiguration = $this->configuration['circuitBreaker'];
-        }
-        if (array_key_exists('metrics', $this->configuration)) {
-            $this->metricsConfiguration = $this->configuration['metrics'];
-        }
+        $this->circuitBreakerConfiguration = $configurationIterator->offsetGet('circuitBreaker');
+        $this->metricsConfiguration = $configurationIterator->offsetGet('metrics');
     }
 
     /**
@@ -121,6 +111,18 @@ class PhystrixCommandConfiguration implements MetricsConfigurationInterface, Cir
             $this->circuitBreakerConfiguration,
             CircuitBreakerConfigurationInterface::CONFIG_KEY_SLEEP_WINDOW_IN_MILLISECONDS,
             0
+        );
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isEnabled()
+    {
+        return $this->getConfigurationValue(
+            $this->circuitBreakerConfiguration,
+            CircuitBreakerConfigurationInterface::CONFIG_KEY_ENABLED,
+            false
         );
     }
 

--- a/library/Odesk/Phystrix/Configuration/RequestCacheConfigurationInterface.php
+++ b/library/Odesk/Phystrix/Configuration/RequestCacheConfigurationInterface.php
@@ -19,28 +19,14 @@
 namespace Odesk\Phystrix\Configuration;
 
 /**
- * Metrics configuration interface
+ * Request-Cache configuration interface
  */
-interface MetricsConfigurationInterface
+interface RequestCacheConfigurationInterface
 {
-    const MT_CONFIG_KEY_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS = 'healthSnapshotIntervalInMilliseconds';
-    const MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_BUCKETS = 'rollingStatisticalWindowBuckets';
-    const MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_IN_MILLISECONDS = 'rollingStatisticalWindowInMilliseconds';
-
-
+    const RC_CONFIG_KEY_ENABLED = 'enabled';
 
     /**
-     * @return integer
+     * @return boolean
      */
-    public function getMetricsHealthSnapshotIntervalInMilliseconds();
-
-    /**
-     * @return integer
-     */
-    public function getMetricsRollingStatisticalWindowBuckets();
-
-    /**
-     * @return integer
-     */
-    public function getMetricsRollingStatisticalWindowInMilliseconds();
+    public function isRequestCacheEnabled();
 }

--- a/library/Odesk/Phystrix/Configuration/RequestLogConfigurationInterface.php
+++ b/library/Odesk/Phystrix/Configuration/RequestLogConfigurationInterface.php
@@ -19,28 +19,14 @@
 namespace Odesk\Phystrix\Configuration;
 
 /**
- * Metrics configuration interface
+ * Request-Log configuration interface
  */
-interface MetricsConfigurationInterface
+interface RequestLogConfigurationInterface
 {
-    const MT_CONFIG_KEY_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS = 'healthSnapshotIntervalInMilliseconds';
-    const MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_BUCKETS = 'rollingStatisticalWindowBuckets';
-    const MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_IN_MILLISECONDS = 'rollingStatisticalWindowInMilliseconds';
-
-
+    const RL_CONFIG_KEY_ENABLED = 'enabled';
 
     /**
-     * @return integer
+     * @return boolean
      */
-    public function getMetricsHealthSnapshotIntervalInMilliseconds();
-
-    /**
-     * @return integer
-     */
-    public function getMetricsRollingStatisticalWindowBuckets();
-
-    /**
-     * @return integer
-     */
-    public function getMetricsRollingStatisticalWindowInMilliseconds();
+    public function isRequestLogEnabled();
 }

--- a/tests/Tests/Odesk/Phystrix/CircuitBreakerFactoryTest.php
+++ b/tests/Tests/Odesk/Phystrix/CircuitBreakerFactoryTest.php
@@ -20,7 +20,7 @@ namespace Tests\Odesk\Phystrix;
 
 use Odesk\Phystrix\CircuitBreakerFactory;
 use Odesk\Phystrix\CommandMetrics;
-use Odesk\Phystrix\Configuration\CircuitBreakerConfigurationInterface;
+use Odesk\Phystrix\Configuration\PhystrixCommandConfiguration;
 use PHPUnit_Framework_MockObject_MockObject;
 
 class CircuitBreakerFactoryTest extends \PHPUnit_Framework_TestCase
@@ -34,12 +34,6 @@ class CircuitBreakerFactoryTest extends \PHPUnit_Framework_TestCase
      * @var CommandMetrics
      */
     protected $metrics;
-
-    protected static $baseConfig = array(
-        'circuitBreaker' => array(
-            'enabled' => true,
-        )
-    );
 
     protected function setUp()
     {
@@ -68,25 +62,25 @@ class CircuitBreakerFactoryTest extends \PHPUnit_Framework_TestCase
         $config = $this->getConfig();
         $circuitBreaker = $this->factory->get('TestCommand', $config, $this->metrics);
         $this->assertAttributeEquals('TestCommand', 'commandKey', $circuitBreaker);
-        $this->assertAttributeEquals($config, 'config', $circuitBreaker);
+        $this->assertAttributeEquals($config, 'circuitBreakerConfig', $circuitBreaker);
         $this->assertAttributeInstanceOf('Odesk\Phystrix\CommandMetrics', 'metrics', $circuitBreaker);
         $this->assertAttributeInstanceOf('Odesk\Phystrix\StateStorageInterface', 'stateStorage', $circuitBreaker);
     }
 
     /**
      * @param bool $isEnabled
-     * @return PHPUnit_Framework_MockObject_MockObject
+     * @return PHPUnit_Framework_MockObject_MockObject|PhystrixCommandConfiguration
      */
     private function getConfig($isEnabled = true)
     {
         $config = $this->getMockBuilder('Odesk\Phystrix\Configuration\PhystrixCommandConfiguration')
             ->disableOriginalConstructor()
             ->setMethods(array(
-                'isEnabled'
+                'isCircuitBreakerEnabled'
             ))
             ->getMock();
 
-        $config->method('isEnabled')->willReturn($isEnabled);
+        $config->method('isCircuitBreakerEnabled')->willReturn($isEnabled);
 
         return $config;
     }

--- a/tests/Tests/Odesk/Phystrix/CircuitBreakerTest.php
+++ b/tests/Tests/Odesk/Phystrix/CircuitBreakerTest.php
@@ -51,6 +51,7 @@ class CircuitBreakerTest extends \PHPUnit_Framework_TestCase
                     'getErrorThresholdPercentage',
                     'getRequestVolumeThreshold',
                     'getSleepWindowInMilliseconds',
+                    'isEnabled',
                     'isForceClosed',
                     'isForceOpened',
                 ))->getMock();

--- a/tests/Tests/Odesk/Phystrix/CircuitBreakerTest.php
+++ b/tests/Tests/Odesk/Phystrix/CircuitBreakerTest.php
@@ -48,23 +48,22 @@ class CircuitBreakerTest extends \PHPUnit_Framework_TestCase
         $commandConfig =
             $this->getMockBuilder('Odesk\Phystrix\Configuration\CircuitBreakerConfigurationInterface')
                 ->setMethods(array(
-                    'getErrorThresholdPercentage',
-                    'getRequestVolumeThreshold',
-                    'getSleepWindowInMilliseconds',
-                    'isEnabled',
-                    'isForceClosed',
-                    'isForceOpened',
+                    'getCircuitBreakerErrorThresholdPercentage',
+                    'getCircuitBreakerRequestVolumeThreshold',
+                    'getCircuitBreakerSleepWindowInMilliseconds',
+                    'isCircuitBreakerEnabled',
+                    'isCircuitBreakerForceClosed',
+                    'isCircuitBreakerForceOpened',
                 ))->getMock();
 
-        $commandConfig->method('getErrorThresholdPercentage')->willReturn(20);
-        $commandConfig->method('getRequestVolumeThreshold')->willReturn(50);
-        $commandConfig->method('getSleepWindowInMilliseconds')->willReturn(5000);
-        $commandConfig->method('isForceClosed')->willReturn($isForceClosed);
-        $commandConfig->method('isForceOpened')->willReturn($isForceOpened);
+        $commandConfig->method('getCircuitBreakerErrorThresholdPercentage')->willReturn(20);
+        $commandConfig->method('getCircuitBreakerRequestVolumeThreshold')->willReturn(50);
+        $commandConfig->method('getCircuitBreakerSleepWindowInMilliseconds')->willReturn(5000);
+        $commandConfig->method('isCircuitBreakerForceClosed')->willReturn($isForceClosed);
+        $commandConfig->method('isCircuitBreakerForceOpened')->willReturn($isForceOpened);
 
         return new CircuitBreaker('TestCommand', $this->metrics, $commandConfig, $this->stateStorage);
     }
-
 
     public function testIsOpenReturnsTrueImmediately()
     {

--- a/tests/Tests/Odesk/Phystrix/CircuitBreakerTest.php
+++ b/tests/Tests/Odesk/Phystrix/CircuitBreakerTest.php
@@ -38,24 +38,28 @@ class CircuitBreakerTest extends \PHPUnit_Framework_TestCase
         $this->stateStorage = $this->getMock('Odesk\Phystrix\StateStorageInterface');
     }
 
-    protected function getCircuitBreaker($config = array())
+    /**
+     * @param bool $isForceClosed
+     * @param bool $isForceOpened
+     * @return CircuitBreaker
+     */
+    protected function getCircuitBreaker($isForceClosed = false, $isForceOpened = false)
     {
-        $commandConfig = new \Zend\Config\Config(array(
-            'circuitBreaker' => array(
-                'enabled' => true,
-                'errorThresholdPercentage' => 50,
-                'forceOpen' => false,
-                'forceClosed' => false,
-                'requestVolumeThreshold' => 50,
-                'sleepWindowInMilliseconds' => 5000,
-                'metrics' => array(
-                    'healthSnapshotIntervalInMilliseconds' => 1000,
-                    'rollingStatisticalWindowInMilliseconds' => 10000,
-                    'rollingStatisticalWindowBuckets' => 10,
-                )
-            ),
-        ), true);
-        $commandConfig->merge(new \Zend\Config\Config($config, true));
+        $commandConfig =
+            $this->getMockBuilder('Odesk\Phystrix\Configuration\CircuitBreakerConfigurationInterface')
+                ->setMethods(array(
+                    'getErrorThresholdPercentage',
+                    'getRequestVolumeThreshold',
+                    'getSleepWindowInMilliseconds',
+                    'isForceClosed',
+                    'isForceOpened',
+                ))->getMock();
+
+        $commandConfig->method('getErrorThresholdPercentage')->willReturn(20);
+        $commandConfig->method('getRequestVolumeThreshold')->willReturn(50);
+        $commandConfig->method('getSleepWindowInMilliseconds')->willReturn(5000);
+        $commandConfig->method('isForceClosed')->willReturn($isForceClosed);
+        $commandConfig->method('isForceOpened')->willReturn($isForceOpened);
 
         return new CircuitBreaker('TestCommand', $this->metrics, $commandConfig, $this->stateStorage);
     }
@@ -100,10 +104,10 @@ class CircuitBreakerTest extends \PHPUnit_Framework_TestCase
         $healthCounts = $this->getMock('Odesk\Phystrix\HealthCountsSnapshot', array(), array(), '', false);
         $healthCounts->expects($this->once())
             ->method('getTotal')
-            ->will($this->returnValue(60)); // total is 60, threshold is set to 50.
+            ->will($this->returnValue(60)); // total is 60, threshold is set to 20.
         $healthCounts->expects($this->once())
             ->method('getErrorPercentage')
-            ->will($this->returnValue(49)); // error percentage threshold is set to 50. 49 should not open the circuit
+            ->will($this->returnValue(19)); // error percentage threshold is set to 20. 19 should not open the circuit
         $this->metrics->expects($this->once())
             ->method('getHealthCounts')
             ->will($this->returnValue($healthCounts));
@@ -151,7 +155,7 @@ class CircuitBreakerTest extends \PHPUnit_Framework_TestCase
     {
         $this->stateStorage->expects($this->never())
             ->method('isCircuitOpen'); // making sure it doesn't get to checking if the circuit is open
-        $circuitBreaker = $this->getCircuitBreaker(array('circuitBreaker' => array('forceOpen' => true)));
+        $circuitBreaker = $this->getCircuitBreaker(false, true);
         $this->assertFalse($circuitBreaker->allowRequest());
     }
 
@@ -159,7 +163,7 @@ class CircuitBreakerTest extends \PHPUnit_Framework_TestCase
     {
         $this->stateStorage->expects($this->never())
             ->method('isCircuitOpen'); // making sure it doesn't get to checking if the circuit is open
-        $circuitBreaker = $this->getCircuitBreaker(array('circuitBreaker' => array('forceClosed' => true)));
+        $circuitBreaker = $this->getCircuitBreaker(true);
         $this->assertTrue($circuitBreaker->allowRequest());
     }
 

--- a/tests/Tests/Odesk/Phystrix/CommandFactoryTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandFactoryTest.php
@@ -18,6 +18,7 @@
  */
 namespace Tests\Odesk\Phystrix;
 
+use ArrayObject;
 use Odesk\Phystrix\CircuitBreakerFactory;
 use Odesk\Phystrix\CommandFactory;
 use Odesk\Phystrix\CommandMetricsFactory;
@@ -29,11 +30,11 @@ class CommandFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetCommand()
     {
-        $config = new \Zend\Config\Config(array(
+        $config = array(
             'default' => array(
                 'fallback' => array('enabled' => true)
             )
-        ));
+        );
         $serviceLocator = new ServiceLocator();
         $stateStorage = $this->getMock('Odesk\Phystrix\StateStorageInterface');
         $circuitBreakerFactory = new CircuitBreakerFactory($stateStorage);
@@ -41,7 +42,7 @@ class CommandFactoryTest extends \PHPUnit_Framework_TestCase
         $requestCache = new RequestCache();
         $requestLog = new RequestLog();
         $commandFactory = new CommandFactory(
-            $config,
+            new ArrayObject($config),
             $serviceLocator,
             $circuitBreakerFactory,
             $commandMetricsFactory,
@@ -54,9 +55,9 @@ class CommandFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test', $command->a);
         $this->assertEquals('hello', $command->b);
         // injects the infrastructure components
-        $expectedDefaultConfig = new \Zend\Config\Config(array(
+        $expectedDefaultConfig = array(
             'fallback' => array('enabled' => true)
-        ), true);
+        );
         $this->assertAttributeEquals($expectedDefaultConfig, 'config', $command);
         $this->assertAttributeEquals($circuitBreakerFactory, 'circuitBreakerFactory', $command);
         $this->assertAttributeEquals($serviceLocator, 'serviceLocator', $command);
@@ -66,7 +67,7 @@ class CommandFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCommandMergesConfig()
     {
-        $config = new \Zend\Config\Config(array(
+        $config = array(
             'default' => array(
                 'fallback' => array('enabled' => true),
                 'customData' => 12345
@@ -75,13 +76,13 @@ class CommandFactoryTest extends \PHPUnit_Framework_TestCase
                 'fallback' => array('enabled' => false),
                 'circuitBreaker' => array('enabled' => false)
             )
-        ));
+        );
         $serviceLocator = new ServiceLocator();
         $stateStorage = $this->getMock('Odesk\Phystrix\StateStorageInterface');
         $circuitBreakerFactory = new CircuitBreakerFactory($stateStorage);
         $commandMetricsFactory = new CommandMetricsFactory($stateStorage);
         $commandFactory = new CommandFactory(
-            $config,
+            new ArrayObject($config),
             $serviceLocator,
             $circuitBreakerFactory,
             $commandMetricsFactory,
@@ -90,11 +91,11 @@ class CommandFactoryTest extends \PHPUnit_Framework_TestCase
         );
         /** @var FactoryCommandMock $command */
         $command = $commandFactory->getCommand('Tests\Odesk\Phystrix\FactoryCommandMock', 'test', 'hello');
-        $expectedConfig = new \Zend\Config\Config(array(
+        $expectedConfig = array(
             'fallback' => array('enabled' => false),
             'circuitBreaker' => array('enabled' => false),
             'customData' => 12345
-        ), true);
+        );
         $this->assertAttributeEquals($expectedConfig, 'config', $command);
     }
 }

--- a/tests/Tests/Odesk/Phystrix/CommandMetricsFactoryTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandMetricsFactoryTest.php
@@ -18,6 +18,7 @@
  */
 namespace Tests\Odesk\Phystrix;
 
+use ArrayObject;
 use Odesk\Phystrix\ArrayStateStorage;
 use Odesk\Phystrix\CommandMetricsFactory;
 
@@ -25,7 +26,7 @@ class CommandMetricsFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testGet()
     {
-        $config = new \Zend\Config\Config(array(
+        $config = new ArrayObject(array(
             'metrics' => array(
                 'rollingStatisticalWindowInMilliseconds' => 10000,
                 'rollingStatisticalWindowBuckets' => 10,
@@ -33,7 +34,8 @@ class CommandMetricsFactoryTest extends \PHPUnit_Framework_TestCase
             )
         ));
         $factory = new CommandMetricsFactory(new ArrayStateStorage());
-        $metrics = $factory->get('TestCommand', $config);
+
+        $metrics = $factory->get('TestCommand', $config->getIterator());
         $this->assertAttributeEquals(2000, 'healthSnapshotIntervalInMilliseconds', $metrics);
 
         $reflection = new \ReflectionClass('Odesk\Phystrix\CommandMetrics');

--- a/tests/Tests/Odesk/Phystrix/CommandMetricsFactoryTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandMetricsFactoryTest.php
@@ -23,20 +23,23 @@ use Odesk\Phystrix\CommandMetricsFactory;
 
 class CommandMetricsFactoryTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @throws \ReflectionException
+     */
     public function testGet()
     {
         $config =
             $this->getMockBuilder('Odesk\Phystrix\Configuration\MetricsConfigurationInterface')
                 ->setMethods(array(
-                    'getHealthSnapshotIntervalInMilliseconds',
-                    'getRollingStatisticalWindowBuckets',
-                    'getRollingStatisticalWindowInMilliseconds'
+                    'getMetricsHealthSnapshotIntervalInMilliseconds',
+                    'getMetricsRollingStatisticalWindowBuckets',
+                    'getMetricsRollingStatisticalWindowInMilliseconds'
                 ))
                 ->getMock();
 
-        $config->method('getHealthSnapshotIntervalInMilliseconds')->willReturn(2000);
-        $config->method('getRollingStatisticalWindowInMilliseconds')->willReturn(10000);
-        $config->method('getRollingStatisticalWindowBuckets')->willReturn(10);
+        $config->method('getMetricsHealthSnapshotIntervalInMilliseconds')->willReturn(2000);
+        $config->method('getMetricsRollingStatisticalWindowInMilliseconds')->willReturn(10000);
+        $config->method('getMetricsRollingStatisticalWindowBuckets')->willReturn(10);
         $factory = new CommandMetricsFactory(new ArrayStateStorage());
 
         $metrics = $factory->get('TestCommand', $config);

--- a/tests/Tests/Odesk/Phystrix/CommandMetricsFactoryTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandMetricsFactoryTest.php
@@ -18,7 +18,6 @@
  */
 namespace Tests\Odesk\Phystrix;
 
-use ArrayObject;
 use Odesk\Phystrix\ArrayStateStorage;
 use Odesk\Phystrix\CommandMetricsFactory;
 
@@ -26,16 +25,21 @@ class CommandMetricsFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testGet()
     {
-        $config = new ArrayObject(array(
-            'metrics' => array(
-                'rollingStatisticalWindowInMilliseconds' => 10000,
-                'rollingStatisticalWindowBuckets' => 10,
-                'healthSnapshotIntervalInMilliseconds' => 2000,
-            )
-        ));
+        $config =
+            $this->getMockBuilder('Odesk\Phystrix\Configuration\MetricsConfigurationInterface')
+                ->setMethods(array(
+                    'getHealthSnapshotIntervalInMilliseconds',
+                    'getRollingStatisticalWindowBuckets',
+                    'getRollingStatisticalWindowInMilliseconds'
+                ))
+                ->getMock();
+
+        $config->method('getHealthSnapshotIntervalInMilliseconds')->willReturn(2000);
+        $config->method('getRollingStatisticalWindowInMilliseconds')->willReturn(10000);
+        $config->method('getRollingStatisticalWindowBuckets')->willReturn(10);
         $factory = new CommandMetricsFactory(new ArrayStateStorage());
 
-        $metrics = $factory->get('TestCommand', $config->getIterator());
+        $metrics = $factory->get('TestCommand', $config);
         $this->assertAttributeEquals(2000, 'healthSnapshotIntervalInMilliseconds', $metrics);
 
         $reflection = new \ReflectionClass('Odesk\Phystrix\CommandMetrics');

--- a/tests/Tests/Odesk/Phystrix/CommandTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandTest.php
@@ -22,7 +22,6 @@ use Odesk\Phystrix\AbstractCommand;
 use Odesk\Phystrix\Exception\RuntimeException;
 use Odesk\Phystrix\RequestCache;
 use Odesk\Phystrix\RequestLog;
-use Zend\Config\Config;
 
 class CommandTest extends \PHPUnit_Framework_TestCase
 {
@@ -72,7 +71,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->requestLog = new RequestLog();
         $this->command->setRequestLog($this->requestLog);
         $this->command->setCircuitBreakerFactory($this->circuitBreakerFactory);
-        $this->command->setConfig(new Config(array(
+        $this->command->setConfig(array(
             'fallback' => array(
                 'enabled' => true,
             ),
@@ -82,7 +81,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             'requestLog' => array(
                 'enabled' => true,
             ),
-        ), true));
+        ), true);
     }
 
     /**
@@ -119,11 +118,11 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testSetTestMergesConfig()
     {
         $command = new CommandMock();
-        $command->setConfig(new Config(array('a' => 1), true));
-        $command->setConfig(new Config(array('b' => 2), true));
-        $this->assertAttributeEquals(new Config(array('a' => 1, 'b' => 2), true), 'config', $command);
-        $command->setConfig(new Config(array('c' => 3), true), false); // false to skip merge
-        $this->assertAttributeEquals(new Config(array('c' => 3), true), 'config', $command);
+        $command->setConfig(array('a' => 1), true);
+        $command->setConfig(array('b' => 2), true);
+        $this->assertAttributeEquals(array('a' => 1, 'b' => 2), 'config', $command);
+        $command->setConfig(array('c' => 3), false); // false to skip merge
+        $this->assertAttributeEquals(array('c' => 3), 'config', $command);
     }
 
     public function testExecuteDefaultCommandKey()
@@ -178,11 +177,11 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testRequestLogOff()
     {
         $this->setUpCommonExpectations();
-        $this->command->setConfig(new Config(array(
+        $this->command->setConfig(array(
             'requestLog' => array(
                 'enabled' => false,
             ),
-        )));
+        ));
         $this->assertEmpty($this->requestLog->getExecutedCommands());
         $this->assertEquals('run result', $this->command->execute());
         $this->assertEmpty($this->requestLog->getExecutedCommands());
@@ -203,11 +202,11 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command->setCircuitBreakerFactory($this->circuitBreakerFactory);
         $command->setRequestCache(new RequestCache());
 
-        $command->setConfig(new Config(array(
+        $command->setConfig(array(
             'requestLog' => array(
                 'enabled' => $logEnabled,
             ),
-        ), true));
+        ), true);
 
         $this->setUpCommonExpectations();
 
@@ -229,17 +228,16 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command->setCircuitBreakerFactory($this->circuitBreakerFactory);
         $command->setRequestLog($this->requestLog);
 
-        $command->setConfig(new Config(array(
+        $command->setConfig(array(
             'requestCache' => array(
                 'enabled' => $cacheEnabled,
             ),
-        ), true));
+        ), true);
 
         $this->setUpCommonExpectations();
 
         $this->assertEquals('run result', $this->command->execute());
     }
-
 
     /**
      * @return array
@@ -379,7 +377,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testExecuteFallbackDisabled()
     {
         $this->setUpCommonExpectations();
-        $this->command->setConfig(new Config(array('fallback' => array('enabled' => false))));
+        $this->command->setConfig(array('fallback' => array('enabled' => false)));
         $this->commandMetrics->expects($this->never()) // because fallback is disabled
             ->method('markFallbackSuccess');
         $this->commandMetrics->expects($this->never()) // because fallback is disabled
@@ -468,7 +466,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testRequestCacheDisabled()
     {
         $this->setUpCommonExpectations();
-        $this->command->setConfig(new Config(array('requestCache' => array('enabled' => false))));
+        $this->command->setConfig(array('requestCache' => array('enabled' => false)));
         /** @var RequestCache|\PHPUnit_Framework_MockObject_MockObject $requestCache */
         $requestCache = $this->getMock('Odesk\Phystrix\RequestCache');
         $requestCache->expects($this->never())
@@ -479,7 +477,6 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->command->setRequestCache($requestCache);
         $this->assertEquals('run result', $this->command->execute());
     }
-
 
     public function testRequestCacheGetCacheKeyNotImplemented()
     {

--- a/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
+++ b/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
@@ -20,8 +20,11 @@ namespace Tests\Odesk\Phystrix\Configuration;
 
 use ArrayObject;
 use Odesk\Phystrix\Configuration\CircuitBreakerConfigurationInterface;
+use Odesk\Phystrix\Configuration\FallbackConfigurationInterface;
 use Odesk\Phystrix\Configuration\MetricsConfigurationInterface;
 use Odesk\Phystrix\Configuration\PhystrixCommandConfiguration;
+use Odesk\Phystrix\Configuration\RequestCacheConfigurationInterface;
+use Odesk\Phystrix\Configuration\RequestLogConfigurationInterface;
 use PHPUnit_Framework_TestCase;
 
 class PhystrixCommandConfigurationTest extends PHPUnit_Framework_TestCase
@@ -35,37 +38,61 @@ class PhystrixCommandConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $configurationArray = new ArrayObject(array(
             'circuitBreaker' => array(
-                CircuitBreakerConfigurationInterface::CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE => 25,
-                CircuitBreakerConfigurationInterface::CONFIG_KEY_ENABLED => true,
-                CircuitBreakerConfigurationInterface::CONFIG_KEY_FORCE_CLOSED => false,
-                CircuitBreakerConfigurationInterface::CONFIG_KEY_FORCE_OPENED => true,
-                CircuitBreakerConfigurationInterface::CONFIG_KEY_REQUEST_VOLUME_THRESHOLD => 32,
-                CircuitBreakerConfigurationInterface::CONFIG_KEY_SLEEP_WINDOW_IN_MILLISECONDS => 5000
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE => 25,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_ENABLED => true,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_FORCE_CLOSED => false,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_FORCE_OPENED => true,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_REQUEST_VOLUME_THRESHOLD => 32,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_SLEEP_WINDOW_IN_MILLISECONDS => 5000
+            ),
+            'fallback' => array(
+                FallbackConfigurationInterface::FB_CONFIG_KEY_ENABLED => true
             ),
             'metrics' => array(
-                MetricsConfigurationInterface::CONFIG_KEY_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS => 2000,
-                MetricsConfigurationInterface::CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_BUCKETS => 10,
-                MetricsConfigurationInterface::CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_IN_MILLISECONDS => 10000,
+                MetricsConfigurationInterface::MT_CONFIG_KEY_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS => 2000,
+                MetricsConfigurationInterface::MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_BUCKETS => 10,
+                MetricsConfigurationInterface::MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_IN_MILLISECONDS => 10000,
+            ),
+            'requestCache' => array(
+                RequestCacheConfigurationInterface::RC_CONFIG_KEY_ENABLED => true
+            ),
+            'requestLog' => array(
+                RequestLogConfigurationInterface::RL_CONFIG_KEY_ENABLED => true
             )
         ));
 
-        $this->configuration = new PhystrixCommandConfiguration($configurationArray->getIterator());
+        $this->configuration = new PhystrixCommandConfiguration($configurationArray);
     }
 
     public function testConfigurationAppliesCircuitBreakerConfigurationFromIterator()
     {
-        $this->assertSame(25, $this->configuration->getErrorThresholdPercentage());
-        $this->assertTrue($this->configuration->isEnabled());
-        $this->assertFalse($this->configuration->isForceClosed());
-        $this->assertTrue($this->configuration->isForceOpened());
-        $this->assertSame(32, $this->configuration->getRequestVolumeThreshold());
-        $this->assertSame(5000, $this->configuration->getSleepWindowInMilliseconds());
+        $this->assertSame(25, $this->configuration->getCircuitBreakerErrorThresholdPercentage());
+        $this->assertTrue($this->configuration->isCircuitBreakerEnabled());
+        $this->assertFalse($this->configuration->isCircuitBreakerForceClosed());
+        $this->assertTrue($this->configuration->isCircuitBreakerForceOpened());
+        $this->assertSame(32, $this->configuration->getCircuitBreakerRequestVolumeThreshold());
+        $this->assertSame(5000, $this->configuration->getCircuitBreakerSleepWindowInMilliseconds());
     }
 
     public function testConfigurationAppliesMetricsConfigurationFromIterator()
     {
-        $this->assertSame(2000, $this->configuration->getHealthSnapshotIntervalInMilliseconds());
-        $this->assertSame(10, $this->configuration->getRollingStatisticalWindowBuckets());
-        $this->assertSame(10000, $this->configuration->getRollingStatisticalWindowInMilliseconds());
+        $this->assertSame(2000, $this->configuration->getMetricsHealthSnapshotIntervalInMilliseconds());
+        $this->assertSame(10, $this->configuration->getMetricsRollingStatisticalWindowBuckets());
+        $this->assertSame(10000, $this->configuration->getMetricsRollingStatisticalWindowInMilliseconds());
+    }
+
+    public function testConfigurationAppliesRequestCacheConfigurationFromIterator()
+    {
+        $this->assertTrue($this->configuration->isRequestCacheEnabled());
+    }
+
+    public function testConfigurationAppliesFallbackConfigurationFromIterator()
+    {
+        $this->assertTrue($this->configuration->isFallbackEnabled());
+    }
+
+    public function testConfigurationAppliesRequestLogConfigurationFromIterator()
+    {
+        $this->assertTrue($this->configuration->isRequestLogEnabled());
     }
 }

--- a/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
+++ b/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
@@ -36,6 +36,7 @@ class PhystrixCommandConfigurationTest extends PHPUnit_Framework_TestCase
         $configurationArray = new ArrayObject(array(
             'circuitBreaker' => array(
                 CircuitBreakerConfigurationInterface::CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE => 25,
+                CircuitBreakerConfigurationInterface::CONFIG_KEY_ENABLED => true,
                 CircuitBreakerConfigurationInterface::CONFIG_KEY_FORCE_CLOSED => false,
                 CircuitBreakerConfigurationInterface::CONFIG_KEY_FORCE_OPENED => true,
                 CircuitBreakerConfigurationInterface::CONFIG_KEY_REQUEST_VOLUME_THRESHOLD => 32,
@@ -54,8 +55,9 @@ class PhystrixCommandConfigurationTest extends PHPUnit_Framework_TestCase
     public function testConfigurationAppliesCircuitBreakerConfigurationFromIterator()
     {
         $this->assertSame(25, $this->configuration->getErrorThresholdPercentage());
-        $this->assertSame(false, $this->configuration->isForceClosed());
-        $this->assertSame(true, $this->configuration->isForceOpened());
+        $this->assertTrue($this->configuration->isEnabled());
+        $this->assertFalse($this->configuration->isForceClosed());
+        $this->assertTrue($this->configuration->isForceOpened());
         $this->assertSame(32, $this->configuration->getRequestVolumeThreshold());
         $this->assertSame(5000, $this->configuration->getSleepWindowInMilliseconds());
     }

--- a/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
+++ b/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
@@ -64,6 +64,27 @@ class PhystrixCommandConfigurationTest extends PHPUnit_Framework_TestCase
         $this->configuration = new PhystrixCommandConfiguration($configurationArray);
     }
 
+    public function testConfigurationAppliesDefaultValuesIfConfigurationsAreMissing()
+    {
+        $this->configuration = new PhystrixCommandConfiguration(new ArrayObject(array()));
+        $this->assertSame(0, $this->configuration->getCircuitBreakerErrorThresholdPercentage());
+        $this->assertFalse($this->configuration->isCircuitBreakerEnabled());
+        $this->assertFalse($this->configuration->isCircuitBreakerForceClosed());
+        $this->assertFalse($this->configuration->isCircuitBreakerForceOpened());
+        $this->assertSame(0, $this->configuration->getCircuitBreakerRequestVolumeThreshold());
+        $this->assertSame(0, $this->configuration->getCircuitBreakerSleepWindowInMilliseconds());
+
+        $this->assertSame(0, $this->configuration->getMetricsHealthSnapshotIntervalInMilliseconds());
+        $this->assertSame(0, $this->configuration->getMetricsRollingStatisticalWindowBuckets());
+        $this->assertSame(0, $this->configuration->getMetricsRollingStatisticalWindowInMilliseconds());
+
+        $this->assertFalse($this->configuration->isRequestCacheEnabled());
+
+        $this->assertFalse($this->configuration->isFallbackEnabled());
+
+        $this->assertFalse($this->configuration->isRequestLogEnabled());
+    }
+
     public function testConfigurationAppliesCircuitBreakerConfigurationFromIterator()
     {
         $this->assertSame(25, $this->configuration->getCircuitBreakerErrorThresholdPercentage());

--- a/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
+++ b/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is a part of the Phystrix library
+ *
+ * Copyright 2013-2014 oDesk Corporation. All Rights Reserved.
+ *
+ * This file is licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Tests\Odesk\Phystrix\Configuration;
+
+use ArrayObject;
+use Odesk\Phystrix\Configuration\CircuitBreakerConfigurationInterface;
+use Odesk\Phystrix\Configuration\MetricsConfigurationInterface;
+use Odesk\Phystrix\Configuration\PhystrixCommandConfiguration;
+use PHPUnit_Framework_TestCase;
+
+class PhystrixCommandConfigurationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PhystrixCommandConfiguration
+     */
+    private $configuration;
+
+    public function setUp()
+    {
+        $configurationArray = new ArrayObject(array(
+            'circuitBreaker' => array(
+                CircuitBreakerConfigurationInterface::CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE => 25,
+                CircuitBreakerConfigurationInterface::CONFIG_KEY_FORCE_CLOSED => false,
+                CircuitBreakerConfigurationInterface::CONFIG_KEY_FORCE_OPENED => true,
+                CircuitBreakerConfigurationInterface::CONFIG_KEY_REQUEST_VOLUME_THRESHOLD => 32,
+                CircuitBreakerConfigurationInterface::CONFIG_KEY_SLEEP_WINDOW_IN_MILLISECONDS => 5000
+            ),
+            'metrics' => array(
+                MetricsConfigurationInterface::CONFIG_KEY_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS => 2000,
+                MetricsConfigurationInterface::CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_BUCKETS => 10,
+                MetricsConfigurationInterface::CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_IN_MILLISECONDS => 10000,
+            )
+        ));
+
+        $this->configuration = new PhystrixCommandConfiguration($configurationArray->getIterator());
+    }
+
+    public function testConfigurationAppliesCircuitBreakerConfigurationFromIterator()
+    {
+        $this->assertSame(25, $this->configuration->getErrorThresholdPercentage());
+        $this->assertSame(false, $this->configuration->isForceClosed());
+        $this->assertSame(true, $this->configuration->isForceOpened());
+        $this->assertSame(32, $this->configuration->getRequestVolumeThreshold());
+        $this->assertSame(5000, $this->configuration->getSleepWindowInMilliseconds());
+    }
+
+    public function testConfigurationAppliesMetricsConfigurationFromIterator()
+    {
+        $this->assertSame(2000, $this->configuration->getHealthSnapshotIntervalInMilliseconds());
+        $this->assertSame(10, $this->configuration->getRollingStatisticalWindowBuckets());
+        $this->assertSame(10000, $this->configuration->getRollingStatisticalWindowInMilliseconds());
+    }
+}

--- a/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
+++ b/tests/Tests/Odesk/Phystrix/Configuration/PhystrixCommandConfigurationTest.php
@@ -85,7 +85,111 @@ class PhystrixCommandConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->configuration->isRequestLogEnabled());
     }
 
-    public function testConfigurationAppliesCircuitBreakerConfigurationFromIterator()
+    public function testConfigurationAppliesCircuitBreakerFromGivenConfiguration()
+    {
+        $this->assertCircuitBreakerConfiguration();
+    }
+
+    public function testConfigurationAppliesCircuitBreakerUpdatesFromGivenConfiguration()
+    {
+        $this->assertCircuitBreakerConfiguration();
+
+        $this->configuration->updateConfiguration(new ArrayObject(array(
+            'circuitBreaker' => array(
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_ERROR_THRESHOLD_PERCENTAGE => 10,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_ENABLED => false,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_FORCE_CLOSED => true,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_FORCE_OPENED => false,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_REQUEST_VOLUME_THRESHOLD => 22,
+                CircuitBreakerConfigurationInterface::CB_CONFIG_KEY_SLEEP_WINDOW_IN_MILLISECONDS => 1300
+            )
+        )));
+
+        $this->assertSame(10, $this->configuration->getCircuitBreakerErrorThresholdPercentage());
+        $this->assertFalse($this->configuration->isCircuitBreakerEnabled());
+        $this->assertTrue($this->configuration->isCircuitBreakerForceClosed());
+        $this->assertFalse($this->configuration->isCircuitBreakerForceOpened());
+        $this->assertSame(22, $this->configuration->getCircuitBreakerRequestVolumeThreshold());
+        $this->assertSame(1300, $this->configuration->getCircuitBreakerSleepWindowInMilliseconds());
+    }
+
+    public function testConfigurationAppliesMetricsFromGivenConfiguration()
+    {
+        $this->assertMetricsConfiguration();
+    }
+
+    public function testConfigurationAppliesMetricsUpdatesFromGivenConfiguration()
+    {
+        $this->assertMetricsConfiguration();
+
+        $this->configuration->updateConfiguration(new ArrayObject(array(
+            'metrics' => array(
+                MetricsConfigurationInterface::MT_CONFIG_KEY_HEALTH_SNAPSHOT_INTERVAL_IN_MILLISECONDS => 500,
+                MetricsConfigurationInterface::MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_BUCKETS => 4,
+                MetricsConfigurationInterface::MT_CONFIG_KEY_ROLLING_STATISTICAL_WINDOW_IN_MILLISECONDS => 700,
+            )
+        )));
+
+        $this->assertSame(500, $this->configuration->getMetricsHealthSnapshotIntervalInMilliseconds());
+        $this->assertSame(4, $this->configuration->getMetricsRollingStatisticalWindowBuckets());
+        $this->assertSame(700, $this->configuration->getMetricsRollingStatisticalWindowInMilliseconds());
+    }
+
+    public function testConfigurationAppliesRequestCacheFromGivenConfiguration()
+    {
+        $this->assertTrue($this->configuration->isRequestCacheEnabled());
+    }
+
+    public function testConfigurationAppliesRequestCacheUpdatesFromGivenConfiguration()
+    {
+        $this->assertTrue($this->configuration->isRequestCacheEnabled());
+
+        $this->configuration->updateConfiguration(new ArrayObject(array(
+            'requestCache' => array(
+                RequestCacheConfigurationInterface::RC_CONFIG_KEY_ENABLED => false
+            ),
+        )));
+
+        $this->assertFalse($this->configuration->isRequestCacheEnabled());
+    }
+
+    public function testConfigurationAppliesFallbackFromGivenConfiguration()
+    {
+        $this->assertTrue($this->configuration->isFallbackEnabled());
+    }
+
+    public function testConfigurationAppliesFallbackUpdatesFromGivenConfiguration()
+    {
+        $this->assertTrue($this->configuration->isFallbackEnabled());
+
+        $this->configuration->updateConfiguration(new ArrayObject(array(
+            'fallback' => array(
+                FallbackConfigurationInterface::FB_CONFIG_KEY_ENABLED => false
+            ),
+        )));
+
+        $this->assertFalse($this->configuration->isFallbackEnabled());
+    }
+
+    public function testConfigurationAppliesRequestLogFromGivenConfiguration()
+    {
+        $this->assertTrue($this->configuration->isRequestLogEnabled());
+    }
+
+    public function testConfigurationAppliesRequestLogUpdatesFromGivenConfiguration()
+    {
+        $this->assertTrue($this->configuration->isRequestLogEnabled());
+
+        $this->configuration->updateConfiguration(new ArrayObject(array(
+            'requestLog' => array(
+                RequestLogConfigurationInterface::RL_CONFIG_KEY_ENABLED => false
+            )
+        )));
+
+        $this->assertFalse($this->configuration->isRequestLogEnabled());
+    }
+
+    private function assertCircuitBreakerConfiguration()
     {
         $this->assertSame(25, $this->configuration->getCircuitBreakerErrorThresholdPercentage());
         $this->assertTrue($this->configuration->isCircuitBreakerEnabled());
@@ -95,25 +199,10 @@ class PhystrixCommandConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertSame(5000, $this->configuration->getCircuitBreakerSleepWindowInMilliseconds());
     }
 
-    public function testConfigurationAppliesMetricsConfigurationFromIterator()
+    private function assertMetricsConfiguration()
     {
         $this->assertSame(2000, $this->configuration->getMetricsHealthSnapshotIntervalInMilliseconds());
         $this->assertSame(10, $this->configuration->getMetricsRollingStatisticalWindowBuckets());
         $this->assertSame(10000, $this->configuration->getMetricsRollingStatisticalWindowInMilliseconds());
-    }
-
-    public function testConfigurationAppliesRequestCacheConfigurationFromIterator()
-    {
-        $this->assertTrue($this->configuration->isRequestCacheEnabled());
-    }
-
-    public function testConfigurationAppliesFallbackConfigurationFromIterator()
-    {
-        $this->assertTrue($this->configuration->isFallbackEnabled());
-    }
-
-    public function testConfigurationAppliesRequestLogConfigurationFromIterator()
-    {
-        $this->assertTrue($this->configuration->isRequestLogEnabled());
     }
 }


### PR DESCRIPTION
With the following changes, the package "Zend\Config" is no longer needed for this library.