### PR TITLE
Automated native_function_invocation fixes

### DIFF
--- a/library/Odesk/Phystrix/AbstractCommand.php
+++ b/library/Odesk/Phystrix/AbstractCommand.php
@@ -117,7 +117,7 @@ abstract class AbstractCommand
             return $this->commandKey;
         } else {
             // If the command key hasn't been defined in the class we use the current class name
-            return get_class($this);
+            return \get_class($this);
         }
     }
 
@@ -353,7 +353,7 @@ abstract class AbstractCommand
                 } catch (FallbackNotAvailableException $fallbackException) {
                     throw new RuntimeException(
                         $message . ' and no fallback available',
-                        get_class($this),
+                        \get_class($this),
                         $originalException
                     );
                 } catch (Exception $fallbackException) {
@@ -361,7 +361,7 @@ abstract class AbstractCommand
                     $this->recordExecutionEvent(self::EVENT_FALLBACK_FAILURE);
                     throw new RuntimeException(
                         $message . ' and failed retrieving fallback',
-                        get_class($this),
+                        \get_class($this),
                         $originalException,
                         $fallbackException
                     );
@@ -369,7 +369,7 @@ abstract class AbstractCommand
             } else {
                 throw new RuntimeException(
                     $message . ' and fallback disabled',
-                    get_class($this),
+                    \get_class($this),
                     $originalException
                 );
             }
@@ -452,7 +452,7 @@ abstract class AbstractCommand
      */
     private function getTimeInMilliseconds()
     {
-        return floor(microtime(true) * 1000);
+        return \floor(\microtime(true) * 1000);
     }
 
     /**

--- a/library/Odesk/Phystrix/ApcStateStorage.php
+++ b/library/Odesk/Phystrix/ApcStateStorage.php
@@ -36,7 +36,7 @@ class ApcStateStorage implements StateStorageInterface
      */
     public function __construct()
     {
-        if (!extension_loaded('apc')) {
+        if (!\extension_loaded('apc')) {
             throw new Exception\ApcNotLoadedException('"apc" PHP extension is required for Phystrix to work');
         }
     }
@@ -111,7 +111,7 @@ class ApcStateStorage implements StateStorageInterface
         // the single test blocked flag will expire automatically in $sleepingWindowInMilliseconds
         // thus allowing us a single test. Notice, APC doesn't allow us to use
         // expire time less than a second.
-        $sleepingWindowInSeconds = ceil($sleepingWindowInMilliseconds / 1000);
+        $sleepingWindowInSeconds = \ceil($sleepingWindowInMilliseconds / 1000);
         apc_add($singleTestFlagKey, true, $sleepingWindowInSeconds);
     }
 
@@ -126,7 +126,7 @@ class ApcStateStorage implements StateStorageInterface
     {
         $singleTestFlagKey = $this->prefix($commandKey . self::SINGLE_TEST_BLOCKED);
         // using 'add' enforces thread safety.
-        $sleepingWindowInSeconds = ceil($sleepingWindowInMilliseconds / 1000);
+        $sleepingWindowInSeconds = \ceil($sleepingWindowInMilliseconds / 1000);
         // another APC limitation is that within the current request variables will never expire.
         return (boolean) apc_add($singleTestFlagKey, true, $sleepingWindowInSeconds);
     }

--- a/library/Odesk/Phystrix/ArrayStateStorage.php
+++ b/library/Odesk/Phystrix/ArrayStateStorage.php
@@ -144,6 +144,6 @@ class ArrayStateStorage implements StateStorageInterface
      */
     private function getTimeInMilliseconds()
     {
-        return floor(microtime(true) * 1000);
+        return \floor(\microtime(true) * 1000);
     }
 }

--- a/library/Odesk/Phystrix/CommandFactory.php
+++ b/library/Odesk/Phystrix/CommandFactory.php
@@ -92,8 +92,8 @@ class CommandFactory
      */
     public function getCommand($class)
     {
-        $parameters = func_get_args();
-        array_shift($parameters);
+        $parameters = \func_get_args();
+        \array_shift($parameters);
 
         $reflection = new ReflectionClass($class);
         /** @var AbstractCommand $command */

--- a/library/Odesk/Phystrix/CommandMetrics.php
+++ b/library/Odesk/Phystrix/CommandMetrics.php
@@ -138,7 +138,7 @@ class CommandMetrics
     public function getHealthCounts()
     {
         // current time in milliseconds
-        $now = microtime(true) * 1000;
+        $now = \microtime(true) * 1000;
         // we should make a new snapshot in case there isn't one yet or when the snapshot interval time has passed
         if (!$this->lastSnapshot
             || $now - $this->lastSnapshot->getTime() >= $this->healthSnapshotIntervalInMilliseconds) {

--- a/library/Odesk/Phystrix/MetricsCounter.php
+++ b/library/Odesk/Phystrix/MetricsCounter.php
@@ -125,7 +125,7 @@ class MetricsCounter
      */
     private function getTimeInMilliseconds()
     {
-        return floor(microtime(true) * 1000);
+        return \floor(\microtime(true) * 1000);
     }
 
     /**
@@ -148,7 +148,7 @@ class MetricsCounter
     private function getBucketIndex($bucketNumber, $time)
     {
         // Getting unique bucket index
-        return floor(($time - $bucketNumber * $this->bucketInMilliseconds) / $this->bucketInMilliseconds);
+        return \floor(($time - $bucketNumber * $this->bucketInMilliseconds) / $this->bucketInMilliseconds);
     }
 
     /**

--- a/library/Odesk/Phystrix/RequestCache.php
+++ b/library/Odesk/Phystrix/RequestCache.php
@@ -92,7 +92,7 @@ class RequestCache
      */
     public function exists($commandKey, $cacheKey)
     {
-        return array_key_exists($commandKey, $this->cachedResults)
-            && array_key_exists($cacheKey, $this->cachedResults[$commandKey]);
+        return \array_key_exists($commandKey, $this->cachedResults)
+            && \array_key_exists($cacheKey, $this->cachedResults[$commandKey]);
     }
 }

--- a/library/Odesk/Phystrix/RequestLog.php
+++ b/library/Odesk/Phystrix/RequestLog.php
@@ -130,11 +130,11 @@ class RequestLog
         $display = $executedCommand->getCommandKey() . "[";
         $events = $executedCommand->getExecutionEvents();
 
-        if (count($events) > 0) {
+        if (\count($events) > 0) {
             foreach ($events as $event) {
                 $display .= "{$event}, ";
             }
-            $display = substr($display, 0, -2);
+            $display = \substr($display, 0, -2);
         } else {
             $display .= "Executed";
         }

--- a/tests/Tests/Odesk/Phystrix/ArrayStateStorageTest.php
+++ b/tests/Tests/Odesk/Phystrix/ArrayStateStorageTest.php
@@ -93,13 +93,13 @@ class ArrayStateStorageTest extends \PHPUnit_Framework_TestCase
         // no matter how many times we check
         $this->assertFalse($this->storage->allowSingleTest('TestCommand', 900));
         // but after the period passes...
-        sleep(1);
+        \sleep(1);
         // we can check again
         $this->assertTrue($this->storage->allowSingleTest('TestCommand', 900));
         // but only once
         $this->assertFalse($this->storage->allowSingleTest('TestCommand', 900));
         // because each check sets new time
-        sleep(1);
+        \sleep(1);
         $this->assertTrue($this->storage->allowSingleTest('TestCommand', 900));
     }
 }

--- a/tests/Tests/Odesk/Phystrix/MetricsCounterTest.php
+++ b/tests/Tests/Odesk/Phystrix/MetricsCounterTest.php
@@ -52,7 +52,7 @@ class MetricsCounterTest extends \PHPUnit_Framework_TestCase
     protected function getExpectedBucketIndex($bucketNumber)
     {
         $timeInMilliseconds = \Odesk\Phystrix\microtime() * 1000;
-        return floor(($timeInMilliseconds - $bucketNumber * 1000) / 1000);
+        return \floor(($timeInMilliseconds - $bucketNumber * 1000) / 1000);
     }
 
     public function testAdd()


### PR DESCRIPTION
Reproduce with:
php php-cs-fixer --rules=native_function_invocation fix ./ --allow-risky=yes
(php-cs-fixer from : https://cs.symfony.com/)

Details:
https://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/