### PR TITLE
Replace all zend references with laminas

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Notice, the extra parameters you pass to the factory’s getCommand method are f
 The factory is instantiated as follows:
 
 ```php
-use Zend\Config\Config;
+use Laminas\Config\Config;
 use Odesk\Phystrix\ApcStateStorage;
 use Odesk\Phystrix\CircuitBreakerFactory;
 use Odesk\Phystrix\CommandMetricsFactory;
@@ -87,12 +87,12 @@ $circuitBreakerFactory = new CircuitBreakerFactory($stateStorage);
 $commandMetricsFactory = new CommandMetricsFactory($stateStorage);
 
 $phystrix = new CommandFactory(
-    $config, new \Zend\Di\ServiceLocator(), $circuitBreakerFactory, $commandMetricsFactory,
+    $config, new \Laminas\Di\ServiceLocator(), $circuitBreakerFactory, $commandMetricsFactory,
     new \Odesk\Phystrix\RequestCache(), new \Odesk\Phystrix\RequestLog()
 );
 ```
 
-The way you store the configuration files is up to you. Phystrix relies on [Zend\Config](https://github.com/zendframework/Component_ZendConfig)  to manage configurations. In this case, __phystrix-config.php__ is a PHP array:
+The way you store the configuration files is up to you. Phystrix relies on [Laminas\Config](https://github.com/laminas/laminas-config)  to manage configurations. In this case, __phystrix-config.php__ is a PHP array:
 
 ```php
 return array(
@@ -160,7 +160,7 @@ Phystrix only works with the command keys. If you have two different commands wi
 Sometimes, you may need to change a parameter when a command is used in a particular context:
 
 ```php
-use Zend\Config\Config;
+use Laminas\Config\Config;
 $myCommand = $phystrix->getCommand('MyCommand', 'Alex');
 $myCommand->setConfig(new Config(array('requestCache' => array('enabled' => false))));
 $result = $myCommand->execute();
@@ -258,7 +258,7 @@ where “timeout” is a custom parameter which Phystrix does not make any use o
     }
 ```
 
-where the client might be a 3rd library you downloaded, or an instance of http client from a framework such as Zend Framework or Symfony or something you wrote yourself.
+where the client might be a 3rd library you downloaded, or an instance of http client from a framework such as Laminas or Symfony or something you wrote yourself.
 
 Of course, having to add this into each command would be suboptimal. Normally, you will have a set of abstract commands, specific to your use cases. E.g. you might have __GenericCurlCommand__ or __GenericGoogleApiCommand__ and __MyCommand__ would extend one of those.
 
@@ -270,10 +270,10 @@ One way would be to extend the __Odesk\Phystrix\CommandFactory__, create your ow
 
 Alternatively, configure the locator instance that __Odesk\Phystrix\CommandFactory__ accepts in the constructor.
 
-The service locator can be anything, implementing the very basic [Zend\Di\LocatorInterface](https://github.com/zendframework/zf2/blob/master/library/Zend/Di/LocatorInterface.php). You can inject an IoC container that will lazily instantiate instance as they are needed, or you can use a simpler, preconfigured, instance of __Zend\Di\ServiceLocator__:
+The service locator can be anything, implementing the very basic [Laminas\Di\LocatorInterface](https://github.com/laminas/laminas-di/blob/2.6.1/src/LocatorInterface.php). You can inject an IoC container that will lazily instantiate instance as they are needed, or you can use a simpler, preconfigured, instance of __Laminas\Di\ServiceLocator__:
 
 ```php
-$serviceLocator = \Zend\Di\ServiceLocator();
+$serviceLocator = \Laminas\Di\ServiceLocator();
 $googleApiRemoteService = new GoogleApi(...);
 $serviceLocator->set('googleApi', $googleApiRemoteService);
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "laminas/laminas-di": "~2.2"
     },
     "require-dev": {
+        "roave/security-advisories": "dev-latest",
         "phpunit/phpunit": "~4.2"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-config": "~2.2",
-        "zendframework/zend-di": "~2.2"
+        "laminas/laminas-config": "~2.2",
+        "laminas/laminas-di": "~2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.2"

--- a/library/Odesk/Phystrix/AbstractCommand.php
+++ b/library/Odesk/Phystrix/AbstractCommand.php
@@ -21,8 +21,8 @@ namespace Odesk\Phystrix;
 use Odesk\Phystrix\Exception\BadRequestException;
 use Odesk\Phystrix\Exception\FallbackNotAvailableException;
 use Odesk\Phystrix\Exception\RuntimeException;
-use Zend\Di\LocatorInterface;
-use Zend\Config\Config;
+use Laminas\Di\LocatorInterface;
+use Laminas\Config\Config;
 use Exception;
 
 /**

--- a/library/Odesk/Phystrix/CircuitBreaker.php
+++ b/library/Odesk/Phystrix/CircuitBreaker.php
@@ -18,7 +18,7 @@
  */
 namespace Odesk\Phystrix;
 
-use Zend\Config\Config;
+use Laminas\Config\Config;
 
 /**
  * Circuit-breaker logic that is hooked into AbstractCommand execution and will stop allowing executions

--- a/library/Odesk/Phystrix/CircuitBreakerFactory.php
+++ b/library/Odesk/Phystrix/CircuitBreakerFactory.php
@@ -18,7 +18,7 @@
  */
 namespace Odesk\Phystrix;
 
-use Zend\Config\Config;
+use Laminas\Config\Config;
 
 /**
  * Factory to keep track of and instantiate new circuit breakers when needed

--- a/library/Odesk/Phystrix/CommandFactory.php
+++ b/library/Odesk/Phystrix/CommandFactory.php
@@ -19,8 +19,8 @@
 namespace Odesk\Phystrix;
 
 use ReflectionClass;
-use Zend\Config\Config;
-use Zend\Di\LocatorInterface;
+use Laminas\Config\Config;
+use Laminas\Di\LocatorInterface;
 
 /**
  * All commands must be created through this factory.

--- a/library/Odesk/Phystrix/CommandMetricsFactory.php
+++ b/library/Odesk/Phystrix/CommandMetricsFactory.php
@@ -18,7 +18,7 @@
  */
 namespace Odesk\Phystrix;
 
-use Zend\Config\Config;
+use Laminas\Config\Config;
 
 /**
  * Factory to keep track of and instantiate new command metrics objects when needed

--- a/tests/Tests/Odesk/Phystrix/CircuitBreakerFactoryTest.php
+++ b/tests/Tests/Odesk/Phystrix/CircuitBreakerFactoryTest.php
@@ -49,7 +49,7 @@ class CircuitBreakerFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $config = self::$baseConfig;
         $config['circuitBreaker']['enabled'] = false;
-        $config = new \Zend\Config\Config($config);
+        $config = new \Laminas\Config\Config($config);
         $circuitBreaker = $this->factory->get('TestCommand', $config, $this->metrics);
         $this->assertInstanceOf('Odesk\Phystrix\NoOpCircuitBreaker', $circuitBreaker);
     }
@@ -58,18 +58,18 @@ class CircuitBreakerFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $config = self::$baseConfig;
         $config['circuitBreaker']['enabled'] = false;
-        $config = new \Zend\Config\Config($config);
+        $config = new \Laminas\Config\Config($config);
         // this will be a NoOpCircuitBreaker
         $circuitBreaker = $this->factory->get('TestCommand', $config, $this->metrics);
         // now trying to get the same circuit breaker with a different config
         $circuitBreakerB
-            = $this->factory->get('TestCommand', new \Zend\Config\Config(self::$baseConfig), $this->metrics);
+            = $this->factory->get('TestCommand', new \Laminas\Config\Config(self::$baseConfig), $this->metrics);
         $this->assertEquals($circuitBreaker, $circuitBreakerB);
     }
 
     public function testGetInjectsParameters()
     {
-        $config = new \Zend\Config\Config(self::$baseConfig);
+        $config = new \Laminas\Config\Config(self::$baseConfig);
         $circuitBreaker = $this->factory->get('TestCommand', $config, $this->metrics);
         $this->assertAttributeEquals('TestCommand', 'commandKey', $circuitBreaker);
         $this->assertAttributeEquals($config, 'config', $circuitBreaker);

--- a/tests/Tests/Odesk/Phystrix/CircuitBreakerTest.php
+++ b/tests/Tests/Odesk/Phystrix/CircuitBreakerTest.php
@@ -40,7 +40,7 @@ class CircuitBreakerTest extends \PHPUnit_Framework_TestCase
 
     protected function getCircuitBreaker($config = array())
     {
-        $commandConfig = new \Zend\Config\Config(array(
+        $commandConfig = new \Laminas\Config\Config(array(
             'circuitBreaker' => array(
                 'enabled' => true,
                 'errorThresholdPercentage' => 50,
@@ -55,7 +55,7 @@ class CircuitBreakerTest extends \PHPUnit_Framework_TestCase
                 )
             ),
         ), true);
-        $commandConfig->merge(new \Zend\Config\Config($config, true));
+        $commandConfig->merge(new \Laminas\Config\Config($config, true));
 
         return new CircuitBreaker('TestCommand', $this->metrics, $commandConfig, $this->stateStorage);
     }

--- a/tests/Tests/Odesk/Phystrix/CommandFactoryTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandFactoryTest.php
@@ -23,13 +23,13 @@ use Odesk\Phystrix\CommandFactory;
 use Odesk\Phystrix\CommandMetricsFactory;
 use Odesk\Phystrix\RequestCache;
 use Odesk\Phystrix\RequestLog;
-use Zend\Di\ServiceLocator;
+use Laminas\Di\ServiceLocator;
 
 class CommandFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetCommand()
     {
-        $config = new \Zend\Config\Config(array(
+        $config = new \Laminas\Config\Config(array(
             'default' => array(
                 'fallback' => array('enabled' => true)
             )
@@ -54,7 +54,7 @@ class CommandFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test', $command->a);
         $this->assertEquals('hello', $command->b);
         // injects the infrastructure components
-        $expectedDefaultConfig = new \Zend\Config\Config(array(
+        $expectedDefaultConfig = new \Laminas\Config\Config(array(
             'fallback' => array('enabled' => true)
         ), true);
         $this->assertAttributeEquals($expectedDefaultConfig, 'config', $command);
@@ -66,7 +66,7 @@ class CommandFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCommandMergesConfig()
     {
-        $config = new \Zend\Config\Config(array(
+        $config = new \Laminas\Config\Config(array(
             'default' => array(
                 'fallback' => array('enabled' => true),
                 'customData' => 12345
@@ -90,7 +90,7 @@ class CommandFactoryTest extends \PHPUnit_Framework_TestCase
         );
         /** @var FactoryCommandMock $command */
         $command = $commandFactory->getCommand('Tests\Odesk\Phystrix\FactoryCommandMock', 'test', 'hello');
-        $expectedConfig = new \Zend\Config\Config(array(
+        $expectedConfig = new \Laminas\Config\Config(array(
             'fallback' => array('enabled' => false),
             'circuitBreaker' => array('enabled' => false),
             'customData' => 12345

--- a/tests/Tests/Odesk/Phystrix/CommandMetricsFactoryTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandMetricsFactoryTest.php
@@ -25,7 +25,7 @@ class CommandMetricsFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testGet()
     {
-        $config = new \Zend\Config\Config(array(
+        $config = new \Laminas\Config\Config(array(
             'metrics' => array(
                 'rollingStatisticalWindowInMilliseconds' => 10000,
                 'rollingStatisticalWindowBuckets' => 10,

--- a/tests/Tests/Odesk/Phystrix/CommandTest.php
+++ b/tests/Tests/Odesk/Phystrix/CommandTest.php
@@ -22,7 +22,7 @@ use Odesk\Phystrix\AbstractCommand;
 use Odesk\Phystrix\Exception\RuntimeException;
 use Odesk\Phystrix\RequestCache;
 use Odesk\Phystrix\RequestLog;
-use Zend\Config\Config;
+use Laminas\Config\Config;
 
 class CommandTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
```
...
Package zendframework/zend-config is abandoned, you should avoid using it. Use laminas/laminas-config instead.
Package zendframework/zend-di is abandoned, you should avoid using it. Use laminas/laminas-di instead.
...
```